### PR TITLE
Add binding redirect for Newtonsoft.Json

### DIFF
--- a/src/legacy/Logary.Services.Rutta/App.config
+++ b/src/legacy/Logary.Services.Rutta/App.config
@@ -144,5 +144,10 @@
     <assemblyIdentity name="System.Xml.XmlSerializer" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.12.0" />
   </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="11.0.0.0" />
+  </dependentAssembly>
 </assemblyBinding></runtime>
 </configuration>


### PR DESCRIPTION
The stackdriver target failed for us due to an assembly mismatch for newtonsoft json. This commit fixes that